### PR TITLE
Add optional calibration_set_id parameter to `cortex circuit run`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Version 0.7
 
 * iqm-client 6.1 support. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
 * Allow user to provide a custom ``calibration_set_id`` when using ``cortex circuit run``. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
-* Update documentation regarding the use of Cortex CLI
+* Update documentation regarding the use of Cortex CLI. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
 
 Version 0.6
 ===========

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.5
+=============
+
+- Bump iqm-client dependency to 6.1
+- Allow user to provide a custom ``calibration_set_id`` when using ``cortex circuit run``
+
 Version 0.4
 =============
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,39 +5,39 @@ Changelog
 Version 0.7
 ===========
 
-- iqm-client 6.1 support. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
-- Allow user to provide a custom ``calibration_set_id`` when using ``cortex circuit run``. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
-- Update documentation regarding the use of Cortex CLI
+* iqm-client 6.1 support. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
+* Allow user to provide a custom ``calibration_set_id`` when using ``cortex circuit run``. `#13 <https://github.com/iqm-finland/cortex-cli/pull/13>`_
+* Update documentation regarding the use of Cortex CLI
 
 Version 0.6
 ===========
 
-- iqm-client 6.0 support. `#14 <https://github.com/iqm-finland/cortex-cli/pull/14>`_
+* iqm-client 6.0 support. `#14 <https://github.com/iqm-finland/cortex-cli/pull/14>`_
 
 Version 0.5
 ===========
 
-- Partial Windows support (no token manager daemon)
-- Performance improvements for faster loading time
+* Partial Windows support (no token manager daemon)
+* Performance improvements for faster loading time
 
 Version 0.4
 ===========
 
-- Bump iqm-client dependency to 5.0
-- Remind the user to login before using operations requiring authentication
+* Bump iqm-client dependency to 5.0
+* Remind the user to login before using operations requiring authentication
 
 Version 0.3
 ===========
 
-- Fix tests for iqm-client 4.3
+* Fix tests for iqm-client 4.3
 
 Version 0.2
 ===========
 
-- Added circuit commands ``cortex circuit validate`` and ``cortex circuit run``
+* Added circuit commands ``cortex circuit validate`` and ``cortex circuit run``
 
 Version 0.1
 ===========
 
-- Authentication token manager daemon
-- Multiple configurations support
+* Authentication token manager daemon
+* Multiple configurations support

--- a/README.rst
+++ b/README.rst
@@ -105,9 +105,11 @@ To log out, run
 
   $ cortex auth logout
 
-This will send a logout request to the authentication server, kill the token manager daemon (if any), and delete the tokens file.
+This will send a logout request to the authentication server, kill the token manager daemon (if any), and delete the
+tokens file.
 
-You may want to stop the token manager, but maintain the session on the server and keep the tokens file intact. To do so, run:
+You may want to stop the token manager, but maintain the session on the server and keep the tokens file intact.
+To do so, run:
 
 .. code-block:: bash
 
@@ -118,7 +120,9 @@ See ``cortex auth logout --help`` for more details.
 Multiple configuration files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, all Cortex CLI commands read the configuration file from the default location ``~/.config/iqm-cortex-cli/config.json``. You can specify a different filepath by providing the ``--config-file`` value, for example:
+By default, all Cortex CLI commands read the configuration file from the default location
+``~/.config/iqm-cortex-cli/config.json``. You can specify a different filepath by providing the ``--config-file`` value,
+for example:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,8 @@ First, Cortex CLI needs initialization, which produces a configuration file:
 
   $ cortex init
 
-Cortex CLI will ask a few questions. You can also pass the values via command line to avoid having an interactive prompt. See ``cortex init --help`` for details.
+Cortex CLI will ask a few questions. You can also pass the values via command line to avoid having an interactive
+prompt. See ``cortex init --help`` for details.
 
 Login
 ^^^^^
@@ -63,6 +64,22 @@ This will ask you to enter your username and password.
    may already have expired), you'll be asked to re-enter your credentials.
 
 See ``cortex auth login --help`` for more details.
+
+Use with Cirq-on-IQM, Qiskit-on-IQM, etc.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adapters based on IQM Client, such as Cirq-on-IQM and Qiskit-on-IQM, can use the tokens file maintained by Cortex CLI.
+This way you don't need to provide the authentication server url, username and password to the adapter library itself.
+To achieve this, follow the instructions printed on the screen after running ``cortex auth login``. Namely, set the
+``IQM_TOKENS_FILE`` environment variable to point to your tokens file, for example:
+
+.. code-block:: bash
+
+  $ export IQM_TOKENS_FILE=/home/user/iqm_tokens.json
+
+Once set, this environment variable is read by the instance of IQM Client associated with the adapter. As a result,
+from the point of view of the adapter it looks like authentication is simply disabled (i.e. no authentication-related
+information has to be provided to the adapter).
 
 Status
 ^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -68,10 +68,10 @@ See ``cortex auth login --help`` for more details.
 Use with Cirq-on-IQM, Qiskit-on-IQM, etc.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Adapters based on IQM Client, such as Cirq-on-IQM and Qiskit-on-IQM, can use the tokens file maintained by Cortex CLI.
-This way you don't need to provide the authentication server url, username and password to the adapter library itself.
-To achieve this, follow the instructions printed on the screen after running ``cortex auth login``. Namely, set the
-``IQM_TOKENS_FILE`` environment variable to point to your tokens file, for example:
+Adapters based on IQM Client, such as Cirq-on-IQM and Qiskit-on-IQM, can take advantage of the tokens file maintained by
+Cortex CLI. This way you won't need to provide the authentication server url, username and password to the adapter
+library itself. To achieve this, follow the instructions printed on the screen after running ``cortex auth login``.
+Namely, set the ``IQM_TOKENS_FILE`` environment variable to point to your tokens file, for example:
 
 .. code-block:: bash
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     requests >= 2.26.0
     pydantic >= 1.8.2, < 2.0
     cirq-iqm >= 7.0, < 8.0
-    iqm-client >= 5.0, < 6.0
+    iqm-client >= 6.1, < 7.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = ~= 3.9

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -435,7 +435,7 @@ def save_tokens_file(path: str, tokens: dict[str, str], auth_server_url: str) ->
                    'Can also be set using the IQM_SETTINGS_PATH environment variable:\n'
                    '`export IQM_SETTINGS_PATH=\"/path/to/settings/file.json\"`\n'
                    'If not set, the latest available calibration will be used.')
-@click.option('--calibration-set-id', type=int, help='ID of the calibration set to be used instead of settings.')
+@click.option('--calibration-set-id', type=int, help='ID of the calibration set to use instead of settings.')
 @click.option('--qubit-mapping', default=None, type=click.File(), envvar='IQM_QUBIT_MAPPING_PATH',
               help='Path to the qubit mapping JSON file. Must consist of a single JSON object, with logical '
                    'qubit names ("Alice", "Bob", ...) as keys, and physical qubit names (appearing in '

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -432,6 +432,7 @@ def save_tokens_file(path: str, tokens: dict[str, str], auth_server_url: str) ->
                    'Can also be set using the IQM_SETTINGS_PATH environment variable:\n'
                    '`export IQM_SETTINGS_PATH=\"/path/to/settings/file.json\"`\n'
                    'If not set, the latest available calibration will be used.')
+@click.option('--calibration-set-id', type=int, help='ID of the calibration set to be used instead of settings.')
 @click.option('--qubit-mapping', default=None, type=click.File(), envvar='IQM_QUBIT_MAPPING_PATH',
               help='Path to the qubit mapping JSON file. Must consist of a single JSON object, with logical '
                    'qubit names ("Alice", "Bob", ...) as keys, and physical qubit names (appearing in '
@@ -459,6 +460,7 @@ def run( #pylint: disable=too-many-arguments, too-many-locals
         verbose: bool,
         shots: int,
         settings: Optional[TextIOWrapper],
+        calibration_set_id: Optional[int],
         qubit_mapping: Optional[TextIOWrapper],
         url: str,
         filename: str,
@@ -512,7 +514,8 @@ def run( #pylint: disable=too-many-arguments, too-many-locals
             [input_circuit],
             qubit_mapping=qubit_mapping,
             shots=shots,
-            settings=settings
+            settings=settings,
+            calibration_set_id=calibration_set_id
         )
         results = iqm_client.wait_for_results(job_id)
         iqm_client.close()

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -518,7 +518,6 @@ def run( #pylint: disable=too-many-arguments, too-many-locals
             calibration_set_id=calibration_set_id
         )
         results = iqm_client.wait_for_results(job_id)
-        iqm_client.close()
     except Exception as ex:
         # just show the error message, not a stack trace
         raise click.ClickException(str(ex)) from ex

--- a/tests/circuit_test.py
+++ b/tests/circuit_test.py
@@ -156,7 +156,32 @@ def test_circuit_run_valid_json_circuit(credentials, config_dict, tokens_dict):
             ['circuit', 'run', os.path.join(resources_path(), 'valid_circuit.json'), '--iqm-json',
              '--config-file', 'config.json',
              '--qubit-mapping', qubit_mapping_path,
-             '--settings', settings_path, '--url', base_url,
+             '--settings', settings_path,
+             '--url', base_url,
+             '--no-auth'])
+    assert 'result' in result.output
+    assert result.exit_code == 0
+    unstub()
+
+
+def test_circuit_run_valid_json_circuit_custom_calibration_set_id(credentials, config_dict, tokens_dict):
+    """
+    Tests that ``circuit run`` succeeds with valid JSON circuit and custom calibration set ID.
+    """
+    base_url = credentials['base_url']
+    expect_jobs_requests(base_url)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('config.json', 'w', encoding='UTF-8') as file:
+            file.write(json.dumps(config_dict))
+        with open('tokens.json', 'w', encoding='utf-8') as file:
+            file.write(json.dumps(tokens_dict))
+        result = CliRunner().invoke(cortex_cli,
+            ['circuit', 'run', os.path.join(resources_path(), 'valid_circuit.json'), '--iqm-json',
+             '--config-file', 'config.json',
+             '--qubit-mapping', qubit_mapping_path,
+             '--calibration-set-id', '24',
+             '--url', base_url,
              '--no-auth'])
     assert 'result' in result.output
     assert result.exit_code == 0


### PR DESCRIPTION
IQM server now allows to specify a `calibration_set_id`. This PR updates `cortex circuit run` command accordingly by adding an optional `--calibration-set-id` flag.