### PR TITLE
Make circuit execution optional extra feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.5
+===========
+
+* Make circuit execution an optional functionality, which requires to install additional dependencies. `#27 <https://github.com/iqm-finland/cortex-cli/pull/27>`_
+
 Version 1.4
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,16 @@ for example:
   $ cortex auth login --config-file /home/joe/config.json
   $ cortex auth logout --config-file /home/joe/config.json
 
+
+Using Cortex CLI for circuits
+-----------------------------
+
+Circuit-related commands require additional dependencies to be installed. To install them, run
+
+.. code-block:: bash
+
+  $ pip install iqm-cortex-cli[circuit]
+
 Circuit validation
 ^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Circuit-related commands require additional dependencies to be installed. To ins
 
 .. code-block:: bash
 
-  $ pip install iqm-cortex-cli[circuit]
+  $ pip install "iqm-cortex-cli[circuit]"
 
 Circuit validation
 ^^^^^^^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,6 @@ install_requires =
     jsonschema >= 4.6.0
     requests >= 2.26.0
     pydantic >= 1.8.2, < 2.0
-    cirq-iqm >= 7.6, < 8.0
-    iqm-client >= 8.1, < 9.0
     pydantic >= 1.10.2
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
@@ -54,6 +52,9 @@ exclude =
 [options.extras_require]
 # Add here additional requirements for extra features, to install with:
 # `pip install iqm-cortex-cli[testing,docs,dev]`
+circuit =
+    cirq-iqm >= 7.6, < 8.0
+    iqm-client >= 8.1, < 9.0
 dev =
     tox == 3.25.1
 testing =

--- a/src/cortex_cli/circuit.py
+++ b/src/cortex_cli/circuit.py
@@ -21,7 +21,7 @@ from cortex_cli.utils import read_file
 CIRCUIT_MISSING_DEPS_MSG = """This requires additional dependencies which are not currently installed.
 To install them, run:
 
-pip install iqm-cortex-cli[circuit]
+pip install "iqm-cortex-cli[circuit]"
 """
 
 

--- a/src/cortex_cli/circuit.py
+++ b/src/cortex_cli/circuit.py
@@ -18,6 +18,12 @@ import click
 
 from cortex_cli.utils import read_file
 
+CIRCUIT_MISSING_DEPS_MSG = """This requires additional dependencies which are not currently installed.
+To install them, run:
+
+pip install iqm-cortex-cli[circuit]
+"""
+
 
 def validate_circuit(filename: str) -> None:
     """Validates the given OpenQASM 2.0 file.
@@ -27,12 +33,16 @@ def validate_circuit(filename: str) -> None:
     Raises:
         ClickException: if circuit is invalid or not found
     """
-    # pylint: disable=import-outside-toplevel
-    from cirq.contrib.qasm_import.exception import QasmException
-    import cirq_iqm
+    try:
+        # pylint: disable=import-outside-toplevel
+        from cirq.contrib.qasm_import.exception import QasmException
+        from cirq_iqm import circuit_from_qasm
+    except ModuleNotFoundError as ex:
+        message = f'{CIRCUIT_MISSING_DEPS_MSG}\nActual error which occured when attempting to load dependencies: {ex}'
+        raise click.ClickException(message) from ex
 
     try:
-        cirq_iqm.circuit_from_qasm(read_file(filename))
+        circuit_from_qasm(read_file(filename))
     except QasmException as ex:
         message = f'Invalid quantum circuit in {filename}\n{ex.message}'
         raise click.ClickException(message) from ex

--- a/src/cortex_cli/utils.py
+++ b/src/cortex_cli/utils.py
@@ -14,6 +14,7 @@
 """
 Utility functions for Cortex CLI.
 """
+import importlib.util
 import json
 
 import click
@@ -51,3 +52,28 @@ def read_json(filename: str) -> dict:
     except json.decoder.JSONDecodeError as error:
         raise click.ClickException(f'Decoding JSON has failed, {error}') from error
     return json_data
+
+
+def package_installed(package_name: str) -> bool:
+    """Checks whether the given package is installed.
+
+    Args:
+        package_name (str): name of the package to check
+    Returns:
+        bool: True if package is installed, False otherwise
+    """
+    if importlib.util.find_spec(package_name):
+        return True
+    return False
+
+
+def missing_packages(required_packages: list[str]) -> list:
+    """Reports which of the given packages are not installed.
+
+    Args:
+        required_packages (list[str]): list of package names to check
+    Returns:
+        list: list of packages that are not installed; subset of required_packages
+    """
+    installed_packages = [pkg for pkg in required_packages if package_installed(pkg)]
+    return list(set(required_packages) - set(installed_packages))

--- a/src/cortex_cli/utils.py
+++ b/src/cortex_cli/utils.py
@@ -67,7 +67,7 @@ def package_installed(package_name: str) -> bool:
     return False
 
 
-def missing_packages(required_packages: list[str]) -> list:
+def missing_packages(required_packages: list[str]) -> list[str]:
     """Reports which of the given packages are not installed.
 
     Args:

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ description =
     Run automated tests.
 extras =
     testing
+    circuit
 commands =
     python --version
     python -m pip --version


### PR DESCRIPTION
How UI looks like after installing Cortex CLI without circuit-related deps (`pip install iqm-cortex-cli`):

```
$ cortex circuit --help
Usage: cortex circuit [OPTIONS] COMMAND [ARGS]...

  Execute your quantum circuits with Cortex CLI. This requires additional
  dependencies which are not currently installed. To install them, run:

  pip install iqm-cortex-cli[circuit]

Options:
  --help  Show this message and exit.

Commands:
  run       Execute a quantum circuit.
  validate  Check if a quantum circuit is valid.
```

```
$ cortex circuit run tests/resources/valid_circuit.qasm --iqm-server-url https://cocos.test.qc.iqm.fi
Error: This requires additional dependencies which are not currently installed.
To install them, run:

pip install iqm-cortex-cli[circuit]

Actual error which occured when attempting to load dependencies: No module named 'iqm_client'
```

```
$ cortex circuit validate tests/resources/valid_circuit.qasm
Error: This requires additional dependencies which are not currently installed.
To install them, run:

pip install iqm-cortex-cli[circuit]

Actual error which occured when attempting to load dependencies: No module named 'cirq_iqm'
```

---

How UI looks like after installing optional extra circuit-related deps (`pip install iqm-cortex-cli[circuit]`):

```bash
$ cortex circuit --help
Usage: cortex circuit [OPTIONS] COMMAND [ARGS]...

  Execute your quantum circuits with Cortex CLI. 

Options:
  --help  Show this message and exit.

Commands:
  run       Execute a quantum circuit.
  validate  Check if a quantum circuit is valid.
```

```
$ cortex circuit run tests/resources/valid_circuit.qasm --iqm-server-url https://cocos.test.qc.iqm.fi
[NORMAL OUTPUT WITH RESULTS]
```

```
$ cortex circuit validate tests/resources/valid_circuit.qasm
[NORMAL OUTPUT WITH RESULTS]
```