### PR TITLE
COMP-613 Delete tokens on logout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 2.2
+===========
+
+* Tokens file gets deleted and logout succeeds even if the authentication server is not available `#32 <https://github.com/iqm-finland/cortex-cli/pull/32>`_
+
 Version 2.1
 ===========
 

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -553,7 +553,7 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
 
             Process(pid).terminate()
             os.remove(tokens_file)
-            logger.info('Logged out successfully.')
+            logger.info('Tokens file deleted. Logged out.')
             return
 
     # 4. Delete tokens, perform logout
@@ -568,7 +568,7 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
                 )
 
             os.remove(tokens_file)
-            logger.info('Logged out successfully.')
+            logger.info('Tokens file deleted. Logged out.')
             return
 
     logger.info('Logout aborted.')

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -547,7 +547,10 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
             try:
                 logout_request(auth_server_url, realm, client_id, refresh_token)
             except (Timeout, ConnectionError, ClientAuthenticationError) as error:
-                raise click.ClickException(f'Error when logging out: {error}') from error
+                logger.warning(
+                    f'Failed to revoke tokens due to error when connecting to authentication server: {error}'
+                )
+
             Process(pid).terminate()
             os.remove(tokens_file)
             logger.info('Logged out successfully.')
@@ -560,7 +563,9 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
             try:
                 logout_request(auth_server_url, realm, client_id, refresh_token)
             except (Timeout, ConnectionError, ClientAuthenticationError) as error:
-                raise click.ClickException(f'Error when logging out: {error}') from error
+                logger.warning(
+                    f'Failed to revoke tokens due to error when connecting to authentication server: {error}'
+                )
 
             os.remove(tokens_file)
             logger.info('Logged out successfully.')

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -548,7 +548,7 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
                 logout_request(auth_server_url, realm, client_id, refresh_token)
             except (Timeout, ConnectionError, ClientAuthenticationError) as error:
                 logger.warning(
-                    f'Failed to revoke tokens due to error when connecting to authentication server: {error}'
+                    'Failed to revoke tokens due to error when connecting to authentication server: %s', error
                 )
 
             Process(pid).terminate()
@@ -564,7 +564,7 @@ def logout(config_file: str, keep_tokens: str, force: bool) -> None:
                 logout_request(auth_server_url, realm, client_id, refresh_token)
             except (Timeout, ConnectionError, ClientAuthenticationError) as error:
                 logger.warning(
-                    f'Failed to revoke tokens due to error when connecting to authentication server: {error}'
+                    'Failed to revoke tokens due to error when connecting to authentication server: %s', error
                 )
 
             os.remove(tokens_file)

--- a/tests/cortex_cli_test.py
+++ b/tests/cortex_cli_test.py
@@ -628,7 +628,7 @@ def test_auth_logout_handles_no_keep_tokens_and_pid(config_dict, credentials):
         expect_process_terminate()
         result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
         assert result.exit_code == 0
-        assert 'Logged out successfully' in result.output
+        assert 'Tokens file deleted. Logged out.' in result.output
 
         # tokens file deleted
         with raises(FileNotFoundError):
@@ -677,7 +677,7 @@ def test_auth_logout_succeeds_with_auth_server_not_available(credentials, config
         expect_process_terminate()
         result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
         assert result.exit_code == 0
-        assert 'Logged out successfully' in result.output
+        assert 'Tokens file deleted. Logged out.' in result.output
 
         # tokens file deleted
         with raises(FileNotFoundError):
@@ -710,7 +710,7 @@ def test_auth_logout_handles_no_keep_tokens_and_no_pid(config_dict, tokens_dict,
         result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
         assert result.exit_code == 0
         assert 'No PID found in tokens file' in result.output
-        assert 'Logged out successfully' in result.output
+        assert 'Tokens file deleted. Logged out.' in result.output
 
         # tokens file deleted
         with raises(FileNotFoundError):
@@ -756,7 +756,7 @@ def test_auth_logout_succeeds_with_auth_server_not_available_no_pid(credentials,
 
         result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
         assert result.exit_code == 0
-        assert 'Logged out successfully' in result.output
+        assert 'Tokens file deleted. Logged out.' in result.output
 
         # tokens file deleted
         with raises(FileNotFoundError):

--- a/tests/cortex_cli_test.py
+++ b/tests/cortex_cli_test.py
@@ -638,6 +638,55 @@ def test_auth_logout_handles_no_keep_tokens_and_pid(config_dict, credentials):
     unstub()
 
 
+def test_auth_logout_succeeds_with_auth_server_not_available(credentials, config_dict, tokens_dict):
+    """
+    Tests that ``cortex auth logout`` deletes tokens file when authentication server fails to process request.
+    """
+    tokens = prepare_tokens(300, 3600, **credentials)
+    url = credentials['auth_server_url']
+    realm = config_dict['realm']
+    client_id = config_dict['client_id']
+    refresh_token = tokens['refresh_token']
+    expect_logout(url, realm, client_id, refresh_token, status_code=401)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('config.json', 'w', encoding='UTF-8') as file:
+            file.write(json.dumps(config_dict))
+        tokens_dict['access_token'] = tokens['access_token']
+        tokens_dict['refresh_token'] = tokens['refresh_token']
+        tokens_dict['pid'] = os.getpid()
+        with open('tokens.json', 'w', encoding='utf-8') as file:
+            file.write(json.dumps(tokens_dict))
+
+        runner.invoke(
+            cortex_cli,
+            [
+                'auth',
+                'login',
+                '--config-file',
+                'config.json',
+                '--username',
+                credentials['username'],
+                '--password',
+                credentials['password'],
+                '--no-refresh',  # do not start token manager
+            ],
+        )
+
+        expect_process_terminate()
+        result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
+        assert result.exit_code == 0
+        assert 'Logged out successfully' in result.output
+
+        # tokens file deleted
+        with raises(FileNotFoundError):
+            with open('tokens.json', 'r', encoding='UTF-8') as file:
+                file.read()
+
+    unstub()
+
+
 # Logout Scenario 4
 def test_auth_logout_handles_no_keep_tokens_and_no_pid(config_dict, tokens_dict, credentials):
     """
@@ -667,6 +716,52 @@ def test_auth_logout_handles_no_keep_tokens_and_no_pid(config_dict, tokens_dict,
         with raises(FileNotFoundError):
             with open('tokens.json', 'r', encoding='utf-8') as file:
                 json.loads(file.read())
+
+    unstub()
+
+
+def test_auth_logout_succeeds_with_auth_server_not_available_no_pid(credentials, config_dict, tokens_dict):
+    """
+    Tests that ``cortex auth logout`` deletes tokens file when authentication server fails to process request.
+    """
+    tokens = prepare_tokens(300, 3600, **credentials)
+    url = credentials['auth_server_url']
+    realm = config_dict['realm']
+    client_id = config_dict['client_id']
+    refresh_token = tokens['refresh_token']
+    expect_logout(url, realm, client_id, refresh_token, status_code=401)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('config.json', 'w', encoding='UTF-8') as file:
+            file.write(json.dumps(config_dict))
+        del tokens_dict['pid']
+        with open('tokens.json', 'w', encoding='utf-8') as file:
+            file.write(json.dumps(tokens_dict))
+
+        runner.invoke(
+            cortex_cli,
+            [
+                'auth',
+                'login',
+                '--config-file',
+                'config.json',
+                '--username',
+                credentials['username'],
+                '--password',
+                credentials['password'],
+                '--no-refresh',  # do not start token manager
+            ],
+        )
+
+        result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
+        assert result.exit_code == 0
+        assert 'Logged out successfully' in result.output
+
+        # tokens file deleted
+        with raises(FileNotFoundError):
+            with open('tokens.json', 'r', encoding='UTF-8') as file:
+                file.read()
 
     unstub()
 
@@ -721,103 +816,6 @@ def test_auth_logout_fails_with_invalid_tokens_file(config_dict, tokens_dict):
         )
         assert result.exit_code == 0
         assert 'Found invalid tokens.json' in result.output
-
-
-# Logout Scenario 3 failure
-def test_auth_logout_fails_by_server_response(credentials, config_dict, tokens_dict):
-    """
-    Tests that ``cortex auth logout`` reports error when server fails to process request.
-    """
-    tokens = prepare_tokens(300, 3600, **credentials)
-    url = credentials['auth_server_url']
-    realm = config_dict['realm']
-    client_id = config_dict['client_id']
-    refresh_token = tokens['refresh_token']
-    expect_logout(url, realm, client_id, refresh_token, status_code=401)
-
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        with open('config.json', 'w', encoding='UTF-8') as file:
-            file.write(json.dumps(config_dict))
-        tokens_dict['access_token'] = tokens['access_token']
-        tokens_dict['refresh_token'] = tokens['refresh_token']
-        with open('tokens.json', 'w', encoding='utf-8') as file:
-            file.write(json.dumps(tokens_dict))
-
-        runner.invoke(
-            cortex_cli,
-            [
-                'auth',
-                'login',
-                '--config-file',
-                'config.json',
-                '--username',
-                credentials['username'],
-                '--password',
-                credentials['password'],
-                '--no-refresh',  # do not start token manager
-            ],
-        )
-
-        result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
-        assert result.exit_code != 0
-        assert 'Error when logging out' in result.output
-
-        # tokens file left unchanged
-        with open('tokens.json', 'r', encoding='utf-8') as file:
-            same_tokens = json.loads(file.read())
-        assert same_tokens['access_token'] == tokens['access_token']
-        assert same_tokens['refresh_token'] == tokens['refresh_token']
-
-    unstub()
-
-
-# Logout Scenario 4 failure
-def test_auth_logout_fails_by_server_response_no_pid(credentials, config_dict, tokens_dict):
-    """
-    Tests that ``cortex auth logout`` reports error when server fails to process request.
-    """
-    tokens = prepare_tokens(300, 3600, **credentials)
-    url = credentials['auth_server_url']
-    realm = config_dict['realm']
-    client_id = config_dict['client_id']
-    refresh_token = tokens['refresh_token']
-    expect_logout(url, realm, client_id, refresh_token, status_code=401)
-
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        with open('config.json', 'w', encoding='UTF-8') as file:
-            file.write(json.dumps(config_dict))
-        del tokens_dict['pid']
-        with open('tokens.json', 'w', encoding='utf-8') as file:
-            file.write(json.dumps(tokens_dict))
-
-        runner.invoke(
-            cortex_cli,
-            [
-                'auth',
-                'login',
-                '--config-file',
-                'config.json',
-                '--username',
-                credentials['username'],
-                '--password',
-                credentials['password'],
-                '--no-refresh',  # do not start token manager
-            ],
-        )
-
-        result = runner.invoke(cortex_cli, ['auth', 'logout', '--config-file', 'config.json', '--force'])
-        assert result.exit_code != 0
-        assert 'Error when logging out' in result.output
-
-        # tokens file left unchanged
-        with open('tokens.json', 'r', encoding='utf-8') as file:
-            same_tokens = json.loads(file.read())
-        assert same_tokens['access_token'] == tokens['access_token']
-        assert same_tokens['refresh_token'] == tokens['refresh_token']
-
-    unstub()
 
 
 # Tests for utility functions


### PR DESCRIPTION
Delete tokens on logout even if the authentication server is not available:
- Catch authentication server error
- Display warning for the user
- Delete tokens file
- Declare logout attempt a success
