### PR TITLE
Fix init-command failing for some orders of options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 4.2
+===========
+
+* Fix ``init`` command non-interactive mode failing for some orders of options `#44 <https://github.com/iqm-finland/cortex-cli/pull/44>`_
+
 Version 4.1
 ===========
 

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -113,7 +113,9 @@ def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
     """
     if ctx.obj and param.name in ctx.obj:
         return path
-    ctx.obj = {param.name: True}
+    if ctx.obj is None:
+        ctx.obj = {}
+    ctx.obj[param.name] = True
 
     # File doesn't exist, no need to confirm overwriting
     if not Path(path).is_file():
@@ -215,6 +217,8 @@ def _validate_auth_server_url(ctx: click.Context, param: click.Option, base_url:
     """
     if ctx.obj and param.name in ctx.obj:
         return base_url
+    if ctx.obj is None:
+        ctx.obj = {}
 
     is_valid = False
     while not is_valid:
@@ -245,6 +249,8 @@ def _validate_auth_realm(ctx: click.Context, param: click.Option, realm: str) ->
     """
     if ctx.obj and param.name in ctx.obj:
         return realm
+    if ctx.obj is None:
+        ctx.obj = {}
 
     base_url = ctx.obj.get('auth_server_url', None)
     if base_url is None:

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -111,10 +111,10 @@ def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
     Returns:
         str: confirmed and finalized path
     """
-    if ctx.obj and param.name in ctx.obj:
-        return path
     if ctx.obj is None:
         ctx.obj = {}
+    if param.name in ctx.obj:
+        return path
     ctx.obj[param.name] = True
 
     # File doesn't exist, no need to confirm overwriting
@@ -215,10 +215,10 @@ def _validate_auth_server_url(ctx: click.Context, param: click.Option, base_url:
     Returns:
         str: validated auth server base URL
     """
-    if ctx.obj and param.name in ctx.obj:
-        return base_url
     if ctx.obj is None:
         ctx.obj = {}
+    if param.name in ctx.obj:
+        return base_url
 
     is_valid = False
     while not is_valid:
@@ -247,10 +247,10 @@ def _validate_auth_realm(ctx: click.Context, param: click.Option, realm: str) ->
     Returns:
         str: validated realm name
     """
-    if ctx.obj and param.name in ctx.obj:
-        return realm
     if ctx.obj is None:
         ctx.obj = {}
+    if param.name in ctx.obj:
+        return realm
 
     base_url = ctx.obj.get('auth_server_url', None)
     if base_url is None:


### PR DESCRIPTION
Previously, depending on the order in which options to `cortex init` were specified, `ctx.obj` (Click Context) could sometimes be uninitialized when it was attempted to be used, resulting in errors. In some cases also existing value of `ctx.obj` was erroneously overwritten.  This fixes these bugs and adds more test cases such that these errors would be detected.