### PR TITLE
Use home directory to store cortex-cli logs

### DIFF
--- a/src/cortex_cli/token_manager.py
+++ b/src/cortex_cli/token_manager.py
@@ -33,7 +33,7 @@ if not platform.system().lower().startswith('win'):
 
 
 def daemonize_token_manager(
-    cycle: int, config: ConfigFile, logfile: str = f'{Path.home()}/.iqm_cortex_cli/token_manager.log'
+    cycle: int, config: ConfigFile, logfile: str = f'{Path.home()}/.local/state/token_manager.log'
 ) -> None:
     """Start a daemon process.
     Args:

--- a/src/cortex_cli/token_manager.py
+++ b/src/cortex_cli/token_manager.py
@@ -42,7 +42,7 @@ def daemonize_token_manager(cycle: int, config: ConfigFile, logfile: Optional[st
     logfile = (
         logfile
         if logfile is not None
-        else f'{os.environ.get("XDG_STATE_HOME", f"{Path.home()}/.local/state")}/token_manager.log'
+        else f'{os.environ.get("XDG_STATE_HOME", f"{Path.home()}/.local/state")}/iqm-cortex-cli/token_manager.log'
     )
     os.makedirs(os.path.dirname(logfile), exist_ok=True)
     with open(logfile, 'w', encoding='UTF-8') as output:

--- a/src/cortex_cli/token_manager.py
+++ b/src/cortex_cli/token_manager.py
@@ -32,15 +32,18 @@ if not platform.system().lower().startswith('win'):
     import daemon
 
 
-def daemonize_token_manager(
-    cycle: int, config: ConfigFile, logfile: str = f'{Path.home()}/.local/state/token_manager.log'
-) -> None:
+def daemonize_token_manager(cycle: int, config: ConfigFile, logfile: Optional[str] = None) -> None:
     """Start a daemon process.
     Args:
         cycle: refresh cycle in seconds
         config: Cortex CLI configuration
         logfile: path to file for writing errors
     """
+    logfile = (
+        logfile
+        if logfile is not None
+        else f'{os.environ.get("XDG_STATE_HOME", f"{Path.home()}/.local/state")}/token_manager.log'
+    )
     os.makedirs(os.path.dirname(logfile), exist_ok=True)
     with open(logfile, 'w', encoding='UTF-8') as output:
         with daemon.DaemonContext(stdout=output, stderr=output):

--- a/src/cortex_cli/token_manager.py
+++ b/src/cortex_cli/token_manager.py
@@ -32,13 +32,16 @@ if not platform.system().lower().startswith('win'):
     import daemon
 
 
-def daemonize_token_manager(cycle: int, config: ConfigFile, logfile: str = '/tmp/token_manager.log') -> None:
+def daemonize_token_manager(
+    cycle: int, config: ConfigFile, logfile: str = f'{Path.home()}/.iqm_cortex_cli/token_manager.log'
+) -> None:
     """Start a daemon process.
     Args:
         cycle: refresh cycle in seconds
         config: Cortex CLI configuration
         logfile: path to file for writing errors
     """
+    os.makedirs(os.path.dirname(logfile), exist_ok=True)
     with open(logfile, 'w', encoding='UTF-8') as output:
         with daemon.DaemonContext(stdout=output, stderr=output):
             start_token_manager(cycle, config)

--- a/tests/token_manager_test.py
+++ b/tests/token_manager_test.py
@@ -16,13 +16,20 @@ Tests for Cortex CLI's auth logic
 """
 
 import json
+import os
+from pathlib import Path
+import platform
 
 from click.testing import CliRunner
-from mockito import unstub
+from mockito import ANY, unstub, when
+import pytest
 
+from cortex_cli import token_manager
 from cortex_cli.models import ConfigFile
-from cortex_cli.token_manager import start_token_manager
 from tests.conftest import expect_token_is_valid, prepare_tokens
+
+if not platform.system().lower().startswith('win'):
+    import daemon
 
 
 def test_start_token_manager(credentials, config_dict, tokens_dict):
@@ -38,10 +45,27 @@ def test_start_token_manager(credentials, config_dict, tokens_dict):
         with open('tokens.json', 'w', encoding='UTF-8') as file:
             file.write(json.dumps(tokens_dict))
 
-        start_token_manager(cycle=1, config=ConfigFile(**config_dict), single_run=True)
+        token_manager.start_token_manager(cycle=1, config=ConfigFile(**config_dict), single_run=True)
 
         with open('tokens.json', 'r', encoding='utf-8') as file:
             saved_tokens = json.loads(file.read())
             assert saved_tokens['access_token'] == expected_tokens['access_token']
             assert saved_tokens['refresh_token'] == expected_tokens['refresh_token']
+    unstub()
+
+
+@pytest.mark.skipif(platform.system().lower().startswith('win'), reason='daemonization does not work on windows')
+def test_daemonize_token_manager(config_dict):
+    """
+    Tests that token manager refreshes tokens.
+    """
+    when(daemon.DaemonContext).__enter__().thenReturn(None)  # pylint: disable=unnecessary-dunder-call
+    when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
+    when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
+        assert os.path.isfile(f'{Path.home()}/.iqm_cortex_cli/token_manager.log')
     unstub()

--- a/tests/token_manager_test.py
+++ b/tests/token_manager_test.py
@@ -19,6 +19,7 @@ import json
 import os
 from pathlib import Path
 import platform
+from unittest import mock
 
 from click.testing import CliRunner
 from mockito import ANY, unstub, when
@@ -57,15 +58,47 @@ def test_start_token_manager(credentials, config_dict, tokens_dict):
 @pytest.mark.skipif(platform.system().lower().startswith('win'), reason='daemonization does not work on windows')
 def test_daemonize_token_manager(config_dict):
     """
-    Tests that token manager refreshes tokens.
+    Tests that token manager daemonizes token management and logs progress.
     """
     when(daemon.DaemonContext).__enter__().thenReturn(None)  # pylint: disable=unnecessary-dunder-call
     when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
     when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
+    when(os).makedirs(f'{Path.home()}/.local/state', exist_ok=True).thenReturn(None)
+    with mock.patch('builtins.open', mock.mock_open()) as mock_log_file:
+        with mock.patch.dict(os.environ, {}):
+            token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
+    mock_log_file.assert_called_with(f'{Path.home()}/.local/state/token_manager.log', 'w', encoding='UTF-8')
+    unstub()
 
-    runner = CliRunner()
 
-    with runner.isolated_filesystem():
-        token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
-        assert os.path.isfile(f'{Path.home()}/.local/state/token_manager.log')
+@pytest.mark.skipif(platform.system().lower().startswith('win'), reason='daemonization does not work on windows')
+def test_daemonize_token_manager_uses_unix_recommended_log_dir(config_dict):
+    """
+    Tests that token manager daemonizes token management uses XDG_STATE_HOME variable for logs.
+    """
+    when(daemon.DaemonContext).__enter__().thenReturn(None)  # pylint: disable=unnecessary-dunder-call
+    when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
+    when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
+    mock_xdg_state_home = 'the/unix/way/to/store/stuff'
+    when(os).makedirs(mock_xdg_state_home, exist_ok=True).thenReturn(None)
+    with mock.patch('builtins.open', mock.mock_open()) as mock_log_file:
+        with mock.patch.dict(os.environ, {'XDG_STATE_HOME': mock_xdg_state_home}):
+            token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
+    mock_log_file.assert_called_with('the/unix/way/to/store/stuff/token_manager.log', 'w', encoding='UTF-8')
+    unstub()
+
+
+@pytest.mark.skipif(platform.system().lower().startswith('win'), reason='daemonization does not work on windows')
+def test_daemonize_token_manager_uses_set_log_dir(config_dict):
+    """
+    Tests that token manager daemonizes token management allows to use specific log directory.
+    """
+    when(daemon.DaemonContext).__enter__().thenReturn(None)  # pylint: disable=unnecessary-dunder-call
+    when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
+    when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
+    logfile = 'my/custom/file.log'
+    when(os).makedirs('my/custom', exist_ok=True).thenReturn(None)
+    with mock.patch('builtins.open', mock.mock_open()) as mock_log_file:
+        token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict), logfile=logfile)
+    mock_log_file.assert_called_with(logfile, 'w', encoding='UTF-8')
     unstub()

--- a/tests/token_manager_test.py
+++ b/tests/token_manager_test.py
@@ -63,11 +63,13 @@ def test_daemonize_token_manager(config_dict):
     when(daemon.DaemonContext).__enter__().thenReturn(None)  # pylint: disable=unnecessary-dunder-call
     when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
     when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
-    when(os).makedirs(f'{Path.home()}/.local/state', exist_ok=True).thenReturn(None)
+    when(os).makedirs(f'{Path.home()}/.local/state/iqm-cortex-cli', exist_ok=True).thenReturn(None)
     with mock.patch('builtins.open', mock.mock_open()) as mock_log_file:
         with mock.patch.dict(os.environ, {}):
             token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
-    mock_log_file.assert_called_with(f'{Path.home()}/.local/state/token_manager.log', 'w', encoding='UTF-8')
+    mock_log_file.assert_called_with(
+        f'{Path.home()}/.local/state/iqm-cortex-cli/token_manager.log', 'w', encoding='UTF-8'
+    )
     unstub()
 
 
@@ -80,11 +82,13 @@ def test_daemonize_token_manager_uses_unix_recommended_log_dir(config_dict):
     when(daemon.DaemonContext).__exit__(ANY, ANY, ANY).thenReturn(None)
     when(token_manager).start_token_manager(1, ConfigFile(**config_dict)).thenReturn(None)
     mock_xdg_state_home = 'the/unix/way/to/store/stuff'
-    when(os).makedirs(mock_xdg_state_home, exist_ok=True).thenReturn(None)
+    when(os).makedirs(f'{mock_xdg_state_home}/iqm-cortex-cli', exist_ok=True).thenReturn(None)
     with mock.patch('builtins.open', mock.mock_open()) as mock_log_file:
         with mock.patch.dict(os.environ, {'XDG_STATE_HOME': mock_xdg_state_home}):
             token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
-    mock_log_file.assert_called_with('the/unix/way/to/store/stuff/token_manager.log', 'w', encoding='UTF-8')
+    mock_log_file.assert_called_with(
+        'the/unix/way/to/store/stuff/iqm-cortex-cli/token_manager.log', 'w', encoding='UTF-8'
+    )
     unstub()
 
 

--- a/tests/token_manager_test.py
+++ b/tests/token_manager_test.py
@@ -67,5 +67,5 @@ def test_daemonize_token_manager(config_dict):
 
     with runner.isolated_filesystem():
         token_manager.daemonize_token_manager(cycle=1, config=ConfigFile(**config_dict))
-        assert os.path.isfile(f'{Path.home()}/.iqm_cortex_cli/token_manager.log')
+        assert os.path.isfile(f'{Path.home()}/.local/state/token_manager.log')
     unstub()


### PR DESCRIPTION
Save the logs of cortex-cli in the users home directory to avoid issues with multi-user systems.

Closes #47 