### PR TITLE
Handle relative paths for config and tokens files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 4.4
+===========
+
+* Support relative paths during init `#52 <https://github.com/iqm-finland/cortex-cli/pull/52>`_
+
+
 Version 4.3
 ===========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.9, <3.11"
 dependencies = [
-    "click >= 7.1.2",
+    "click >= 7.1.2, < 8.1.4",  # upper limit until https://github.com/pallets/click/issues/2558 is fixed
     "jsonschema >= 4.6.0",
     "mechanize >= 0.4.8",
     "psutil >= 5.9.2",

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -127,7 +127,7 @@ def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
         if click.confirm(msg, default=None):
             return path
 
-        new_path = click.prompt('New file path', type=click.Path(dir_okay=False, writable=True))
+        new_path = click.prompt('New file path', type=click.Path(dir_okay=False, writable=True, resolve_path=True))
 
         if new_path == path:
             continue
@@ -293,7 +293,7 @@ def cortex_cli() -> None:
     prompt='Where to save config',
     callback=_validate_path,
     default=CortexCliCommand.default_config_path,
-    type=click.Path(dir_okay=False, writable=True),
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
     help='Location where the configuration file will be saved.',
 )
 @click.option(
@@ -301,7 +301,7 @@ def cortex_cli() -> None:
     prompt='Where to save auth tokens',
     callback=_validate_path,
     default=CortexCliCommand.default_tokens_path,
-    type=click.Path(dir_okay=False, writable=True),
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
     help='Location where the tokens file will be saved.',
 )
 @click.option(
@@ -374,7 +374,7 @@ def auth() -> None:
 @click.option(
     '--config-file',
     default=CortexCliCommand.default_config_path,
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
     help='Location of the configuration file to be used.',
 )
 @click.option('-v', '--verbose', is_flag=True, help='Print extra information.')
@@ -511,7 +511,7 @@ def _refresh_tokens(
 @click.option(
     '--config-file',
     default=CortexCliCommand.default_config_path,
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
     help='Location of the configuration file to be used.',
 )
 @click.option('--username', help='Username for authentication.')
@@ -609,7 +609,9 @@ Refer to IQM Client documentation for details: https://iqm-finland.github.io/iqm
 
 @auth.command()
 @click.option(
-    '--config-file', type=click.Path(exists=True, dir_okay=False), default=CortexCliCommand.default_config_path
+    '--config-file',
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    default=CortexCliCommand.default_config_path,
 )
 @click.option('--keep-tokens', is_flag=True, default=False, help="Don't delete tokens file, but kill token manager.")
 @click.option('-f', '--force', is_flag=True, default=False, help="Don't ask for confirmation.")

--- a/src/cortex_cli/cortex_cli.py
+++ b/src/cortex_cli/cortex_cli.py
@@ -21,6 +21,7 @@ import os
 from pathlib import Path
 import platform
 import sys
+from typing import Any, Optional
 
 import click
 from psutil import Process
@@ -81,6 +82,22 @@ def _set_log_level_by_verbosity(verbose: bool) -> int:
     return logging.INFO
 
 
+class ResolvedPath(click.Path):
+    """A click parameter type for a resolved path.
+    Normal ``click.Path(resolve_path=True)`` fails under Windows running python <= 3.9.
+    See https://github.com/pallets/click/issues/2466
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def convert(self, value: Any, param: Optional[click.Parameter], ctx: Optional[click.Context]) -> Any:
+        abspath = Path(value).absolute()
+        # fsdecode to ensure that the return value is a str.
+        # (with click<8.0.3 Path.convert will return Path if passed a Path)
+        return os.fsdecode(super().convert(abspath, param, ctx))
+
+
 def _read_json(path: str) -> dict:
     """Read a JSON file.
 
@@ -127,7 +144,7 @@ def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
         if click.confirm(msg, default=None):
             return path
 
-        new_path = click.prompt('New file path', type=click.Path(dir_okay=False, writable=True, resolve_path=True))
+        new_path = click.prompt('New file path', type=ResolvedPath(dir_okay=False, writable=True, resolve_path=True))
 
         if new_path == path:
             continue
@@ -293,7 +310,7 @@ def cortex_cli() -> None:
     prompt='Where to save config',
     callback=_validate_path,
     default=CortexCliCommand.default_config_path,
-    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+    type=ResolvedPath(dir_okay=False, writable=True, resolve_path=True),
     help='Location where the configuration file will be saved.',
 )
 @click.option(
@@ -301,7 +318,7 @@ def cortex_cli() -> None:
     prompt='Where to save auth tokens',
     callback=_validate_path,
     default=CortexCliCommand.default_tokens_path,
-    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+    type=ResolvedPath(dir_okay=False, writable=True, resolve_path=True),
     help='Location where the tokens file will be saved.',
 )
 @click.option(
@@ -374,7 +391,7 @@ def auth() -> None:
 @click.option(
     '--config-file',
     default=CortexCliCommand.default_config_path,
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=ResolvedPath(exists=True, dir_okay=False, resolve_path=True),
     help='Location of the configuration file to be used.',
 )
 @click.option('-v', '--verbose', is_flag=True, help='Print extra information.')
@@ -511,7 +528,7 @@ def _refresh_tokens(
 @click.option(
     '--config-file',
     default=CortexCliCommand.default_config_path,
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=ResolvedPath(exists=True, dir_okay=False, resolve_path=True),
     help='Location of the configuration file to be used.',
 )
 @click.option('--username', help='Username for authentication.')
@@ -610,7 +627,7 @@ Refer to IQM Client documentation for details: https://iqm-finland.github.io/iqm
 @auth.command()
 @click.option(
     '--config-file',
-    type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+    type=ResolvedPath(exists=True, dir_okay=False, resolve_path=True),
     default=CortexCliCommand.default_config_path,
 )
 @click.option('--keep-tokens', is_flag=True, default=False, help="Don't delete tokens file, but kill token manager.")

--- a/tests/cortex_cli_auth_login_test.py
+++ b/tests/cortex_cli_auth_login_test.py
@@ -21,12 +21,14 @@ import os
 from click.testing import CliRunner
 import mechanize  # type: ignore
 from mockito import ANY, mock, unstub, when
+import pytest
 
 from cortex_cli.cortex_cli import cortex_cli
 from tests.conftest import expect_token_is_valid, make_token, prepare_tokens
 
 
-def test_auth_login_succeeds(config_dict, credentials):
+@pytest.mark.parametrize('absolute_path', [True, False])
+def test_auth_login_succeeds(config_dict, credentials, absolute_path):
     """
     Tests that ``cortex auth login`` performs authentication and saves tokens.
     """
@@ -35,6 +37,8 @@ def test_auth_login_succeeds(config_dict, credentials):
     runner = CliRunner()
     with runner.isolated_filesystem():
         config_dict['username'] = credentials['username']
+        if absolute_path:
+            config_dict['tokens_file'] = os.path.join(os.getcwd(), config_dict['tokens_file'])  # use absolute path
         with open('config.json', 'w', encoding='UTF-8') as file:
             file.write(json.dumps(config_dict))
 

--- a/tests/cortex_cli_init_test.py
+++ b/tests/cortex_cli_init_test.py
@@ -59,7 +59,8 @@ def test_init_saves_config_file(config_dict, first_option):
         assert 'Cortex CLI initialized successfully' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
-            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
+            tmp_tokens_path = os.path.join(os.getcwd(), config_dict['tokens_file'])
+            config_dict['tokens_file'] = tmp_tokens_path  # update path to current temporary dir created by CliRunner
             assert loaded_config == config_dict
     unstub()
 
@@ -98,7 +99,8 @@ def test_init_overwrites_config_file(config_dict):
         assert 'already exists. Overwrite?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
-            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
+            tmp_tokens_path = os.path.join(os.getcwd(), config_dict['tokens_file'])
+            config_dict['tokens_file'] = tmp_tokens_path  # update path to current temporary dir created by CliRunner
             assert loaded_config == config_dict
             assert loaded_config != old_config_dict
     unstub()
@@ -172,7 +174,8 @@ def test_init_warns_user_if_auth_server_url_is_invalid(config_dict):
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
-            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
+            tmp_tokens_path = os.path.join(os.getcwd(), config_dict['tokens_file'])
+            config_dict['tokens_file'] = tmp_tokens_path  # update path to current temporary dir created by CliRunner
             assert loaded_config == {**config_dict, 'auth_server_url': invalid_url}
     unstub()
 
@@ -208,7 +211,8 @@ def test_init_warns_user_if_realm_is_invalid(config_dict):
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
-            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
+            tmp_tokens_path = os.path.join(os.getcwd(), config_dict['tokens_file'])
+            config_dict['tokens_file'] = tmp_tokens_path  # update path to current temporary dir created by CliRunner
             assert loaded_config == {**config_dict, 'realm': invalid_realm}
     unstub()
 
@@ -243,6 +247,7 @@ def test_init_lets_user_to_enter_correct_auth_server_url_if_the_original_is_inva
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
-            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
+            tmp_tokens_path = os.path.join(os.getcwd(), config_dict['tokens_file'])
+            config_dict['tokens_file'] = tmp_tokens_path  # update path to current temporary dir created by CliRunner
             assert loaded_config == config_dict
     unstub()

--- a/tests/cortex_cli_init_test.py
+++ b/tests/cortex_cli_init_test.py
@@ -29,7 +29,7 @@ from tests.conftest import expect_process_terminate, prepare_auth_server_urls
 
 
 @pytest.mark.parametrize('first_option', ['--config-file', '--tokens-file', '--auth-server-url', '--client-id'])
-def test_init_saves_config_file(config_dict, first_option):
+def test_init_saves_config_file(config_dict, first_option, tmp_path):
     """
     Tests that ``cortex init`` produces config file.
 
@@ -38,7 +38,7 @@ def test_init_saves_config_file(config_dict, first_option):
     """
     prepare_auth_server_urls(config_dict)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         options_map = {
             '--config-file': 'config.json',
             '--tokens-file': config_dict['tokens_file'],
@@ -65,13 +65,13 @@ def test_init_saves_config_file(config_dict, first_option):
     unstub()
 
 
-def test_init_overwrites_config_file(config_dict):
+def test_init_overwrites_config_file(config_dict, tmp_path):
     """
     Tests that ``cortex init`` prompts to overwrite, and overwrites existing config file.
     """
     prepare_auth_server_urls(config_dict)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         old_config_dict = config_dict.copy()
         old_config_dict['auth_server_url'] = 'https://to.be.overwritten.com'
         old_config_dict['username'] = 'to_be_overwritten'
@@ -106,13 +106,13 @@ def test_init_overwrites_config_file(config_dict):
     unstub()
 
 
-def test_init_kills_daemon_and_removes_token_file(config_dict, tokens_dict):
+def test_init_kills_daemon_and_removes_token_file(config_dict, tokens_dict, tmp_path):
     """
     Tests that ``cortex init`` kills active token manager daemon and removes old token file.
     """
     prepare_auth_server_urls(config_dict)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         # emulate a running daemon by storing a real PID
         tokens_dict['pid'] = os.getpid()
 
@@ -144,14 +144,14 @@ def test_init_kills_daemon_and_removes_token_file(config_dict, tokens_dict):
     unstub()
 
 
-def test_init_warns_user_if_auth_server_url_is_invalid(config_dict):
+def test_init_warns_user_if_auth_server_url_is_invalid(config_dict, tmp_path):
     """
     Tests that ``cortex init`` prompts user to either accept invalid auth server URL or to enter another one.
     """
     invalid_url = 'http://invalid.com'
     prepare_auth_server_urls(config_dict, invalid_url)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             cortex_cli,
             [
@@ -180,7 +180,7 @@ def test_init_warns_user_if_auth_server_url_is_invalid(config_dict):
     unstub()
 
 
-def test_init_warns_user_if_realm_is_invalid(config_dict):
+def test_init_warns_user_if_realm_is_invalid(config_dict, tmp_path):
     """
     Tests that ``cortex init`` prompts user to either accept invalid realm or to enter another one.
     """
@@ -188,7 +188,7 @@ def test_init_warns_user_if_realm_is_invalid(config_dict):
     invalid_realm = 'invalid'
     prepare_auth_server_urls(config_dict, invalid_realm=invalid_realm)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             cortex_cli,
             [
@@ -217,14 +217,14 @@ def test_init_warns_user_if_realm_is_invalid(config_dict):
     unstub()
 
 
-def test_init_lets_user_to_enter_correct_auth_server_url_if_the_original_is_invalid(config_dict):
+def test_init_lets_user_to_enter_correct_auth_server_url_if_the_original_is_invalid(config_dict, tmp_path):
     """
     Tests that ``cortex init`` prompts user to enter another URL if the original is invalid.
     """
     invalid_url = 'http://invalid.com'
     prepare_auth_server_urls(config_dict, invalid_url)
     runner = CliRunner()
-    with runner.isolated_filesystem():
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         result = runner.invoke(
             cortex_cli,
             [

--- a/tests/cortex_cli_init_test.py
+++ b/tests/cortex_cli_init_test.py
@@ -59,6 +59,7 @@ def test_init_saves_config_file(config_dict, first_option):
         assert 'Cortex CLI initialized successfully' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
+            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
             assert loaded_config == config_dict
     unstub()
 
@@ -97,6 +98,7 @@ def test_init_overwrites_config_file(config_dict):
         assert 'already exists. Overwrite?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
+            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
             assert loaded_config == config_dict
             assert loaded_config != old_config_dict
     unstub()
@@ -170,6 +172,7 @@ def test_init_warns_user_if_auth_server_url_is_invalid(config_dict):
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
+            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
             assert loaded_config == {**config_dict, 'auth_server_url': invalid_url}
     unstub()
 
@@ -205,6 +208,7 @@ def test_init_warns_user_if_realm_is_invalid(config_dict):
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
+            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
             assert loaded_config == {**config_dict, 'realm': invalid_realm}
     unstub()
 
@@ -239,5 +243,6 @@ def test_init_lets_user_to_enter_correct_auth_server_url_if_the_original_is_inva
         assert 'Do you still want to use it?' in result.output
         with open('config.json', 'r', encoding='utf-8') as config_file:
             loaded_config = json.load(config_file)
+            config_dict['tokens_file'] = f'{os.getcwd()}/{config_dict["tokens_file"]}'  # update path to current tempdir
             assert loaded_config == config_dict
     unstub()

--- a/tests/cortex_cli_init_test.py
+++ b/tests/cortex_cli_init_test.py
@@ -29,7 +29,8 @@ from tests.conftest import expect_process_terminate, prepare_auth_server_urls
 
 
 @pytest.mark.parametrize('first_option', ['--config-file', '--tokens-file', '--auth-server-url', '--client-id'])
-def test_init_saves_config_file(config_dict, first_option, tmp_path):
+@pytest.mark.parametrize('absolute_path', [True, False])
+def test_init_saves_config_file(config_dict, first_option, tmp_path, absolute_path):
     """
     Tests that ``cortex init`` produces config file.
 
@@ -40,8 +41,10 @@ def test_init_saves_config_file(config_dict, first_option, tmp_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
         options_map = {
-            '--config-file': 'config.json',
-            '--tokens-file': config_dict['tokens_file'],
+            '--config-file': os.path.join(os.getcwd(), 'config.json') if absolute_path else 'config.json',
+            '--tokens-file': os.path.join(os.getcwd(), config_dict['tokens_file'])
+            if absolute_path
+            else config_dict['tokens_file'],
             '--auth-server-url': config_dict['auth_server_url'],
             '--realm': config_dict['realm'],
             '--client-id': config_dict['client_id'],


### PR DESCRIPTION
Adds support for inputting relative paths during initialization. Paths are now expanded to absolute paths. 

Tilde `~` as a home-dir shortcut is **not** expanded. The feature request was [raised](https://github.com/pallets/click/issues?q=tilde) in Click multiple times, and the maintainers' position is [clear](https://github.com/pallets/click/pull/60): this kind of expansion should be handled by user's shell, not by the program; this is the behavior of standard tools, and Click-based apps should behave the same. 