### PR TITLE
Do not apply validation logic to parameters that are submitted via command line

### DIFF
--- a/src/iqm/cortex_cli/cortex_cli.py
+++ b/src/iqm/cortex_cli/cortex_cli.py
@@ -121,6 +121,9 @@ def _read_json(path: str) -> dict:
 def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
     """Callback for CLI prompt. If needed, confirmation to overwrite is prompted.
 
+    The validation logic is not applied if the parameter is supplied via the
+    command line.
+
     Args:
         ctx: click context
         param: click prompt param object
@@ -133,6 +136,14 @@ def _validate_path(ctx: click.Context, param: click.Path, path: str) -> str:
     if param.name in ctx.obj:
         return path
     ctx.obj[param.name] = True
+
+    # Skip parameter validation completely if the parameter comes from command line
+    if ctx.get_parameter_source(param.name):
+        if ctx.get_parameter_source(param.name).name == "COMMANDLINE":
+            cmd_line_opt_name = param.opts[0]
+            msg = click.style(f'Skipping validation of "{cmd_line_opt_name}", using the provided value "{path}" as is', fg='yellow')
+            click.echo(msg)
+            return path
 
     # File doesn't exist, no need to confirm overwriting
     if not Path(path).is_file():
@@ -225,6 +236,9 @@ def _validate_auth_server_url(ctx: click.Context, param: click.Option, base_url:
        - is accessible
        - points to an authentication server
 
+    The validation logic is not applied if the parameter is supplied via the
+    command line.
+
     Args:
         ctx: click context
         param: click prompt param object
@@ -236,6 +250,14 @@ def _validate_auth_server_url(ctx: click.Context, param: click.Option, base_url:
         ctx.obj = {}
     if param.name in ctx.obj:
         return base_url
+
+    # Skip parameter validation completely if the parameter comes from command line
+    if ctx.get_parameter_source(param.name):
+        if ctx.get_parameter_source(param.name).name == "COMMANDLINE":
+            cmd_line_opt_name = param.opts[0]
+            msg = click.style(f'Skipping validation of "{cmd_line_opt_name}", using the provided value "{base_url}" as is', fg='yellow')
+            click.echo(msg)
+            return base_url
 
     is_valid = False
     while not is_valid:
@@ -257,6 +279,9 @@ def _validate_auth_server_url(ctx: click.Context, param: click.Option, base_url:
 def _validate_auth_realm(ctx: click.Context, param: click.Option, realm: str) -> str:
     """Checks if provided realm exists on auth server.
 
+    The validation logic is not applied if the parameter is supplied via the
+    command line.
+
     Args:
         ctx: click context
         param: click prompt param object
@@ -268,6 +293,14 @@ def _validate_auth_realm(ctx: click.Context, param: click.Option, realm: str) ->
         ctx.obj = {}
     if param.name in ctx.obj:
         return realm
+
+    # Skip parameter validation completely if the parameter comes from command line
+    if ctx.get_parameter_source(param.name):
+        if ctx.get_parameter_source(param.name).name == "COMMANDLINE":
+            cmd_line_opt_name = param.opts[0]
+            msg = click.style(f'Skipping validation of "{cmd_line_opt_name}", using the provided value "{realm}" as is', fg='yellow')
+            click.echo(msg)
+            return realm
 
     base_url = ctx.obj.get('auth_server_url', None)
     if base_url is None:


### PR DESCRIPTION
Use the values of parameters "as is"