### PR TITLE
Use GitHub Action Trusted Publisher for PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,13 @@
-name: Upload to PyPI and publish documentation
+name: Upload package to PyPI and publish documentation
 
 on:
   release:
     types: [published]
   workflow_dispatch:
   workflow_call:
-    secrets:
-      PYPI_USER:
-        required: true
-      PYPI_PASSWORD:
-        required: true
 
 jobs:
-  push_to_pypi:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,15 +21,30 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,cicd]"
-      - name: Build and publish
-        run: |
-          tox -e build
-          python -m twine check dist/*
-          python -m twine upload dist/*
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          python -m pip install build==1.0.3
+      - name: Build distribution
+        run: python -m build
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist
+
+  push_to_pypi:
+    runs-on: ubuntu-latest
+    needs:
+    - build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/iqm-cortex-cli
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@v4
+      - name: Publish distribution packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   publish_docs:
     runs-on: ubuntu-latest
@@ -83,7 +93,7 @@ jobs:
           pip-licenses --format=confluence --with-urls > licenses.txt
           cat -n licenses.txt | sort -uk2 | sort -n | cut -f2- > tmp && mv tmp licenses.txt  # remove duplicate lines
       - name: Upload license information artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dependencies-licenses
           path: licenses.txt

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -40,7 +40,4 @@ jobs:
   # created by the above job create_tag_and_release. Here we trigger the said workflow manually.
   trigger_publishing:
     needs: create_tag_and_release
-    uses: iqm-finland/cortex-cli/.github/workflows/publish.yml@main
-    secrets:
-      PYPI_USER: ${{ secrets.PYPI_USER }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    uses: ./.github/workflows/publish.yml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 5.10
+===========
+
+* Use GitHub Action as a Trusted Publisher to publish packages to PyPI. `#68 <https://github.com/iqm-finland/cortex-cli/pull/68>`_
+
 Version 5.9
 ===========
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 Version 5.10
-===========
+============
 
 * Use GitHub Action as a Trusted Publisher to publish packages to PyPI. `#68 <https://github.com/iqm-finland/cortex-cli/pull/68>`_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ docs = [
     "sphinx == 7.2.6",
     "sphinx-book-theme == 1.1.2",
 ]
-cicd = [
-    "twine == 4.0.2"
-]
 
 [project.scripts]
 cortex = "iqm.cortex_cli.cortex_cli:cortex_cli"


### PR DESCRIPTION
- Separate ```push_to_pypi``` job into two jobs: ```build``` and ```push_to_pypi```
- Use ```publish``` workflow file from current feature branch rather than ```main``` branch
- Do not use ```tox``` in ```publish``` workflow to build and upload package
- Remove ```twine``` dependency
- Remove references to PyPI secrets
