### PR TITLE
Fix broken pypi publishing by disabling attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Publish distribution packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+            attestations: false
 
   publish_docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 6.1
+============
+
+* Disable attestations on ``gh-action-pypi-publish`` to fix failing PyPI publishing
+  `#72 <https://github.com/iqm-finland/cortex-cli/pull/72>`_
+
 Version 6.0
 ============
 


### PR DESCRIPTION
Same fix as https://github.com/iqm-finland/iqm-client/pull/143.